### PR TITLE
Improve logo visibility on Dark Theme

### DIFF
--- a/src/.vuepress/styles/index.scss
+++ b/src/.vuepress/styles/index.scss
@@ -1,1 +1,4 @@
 // place your custom styles here
+html[data-theme="dark"] img[src="/coffee.svg"]{
+    filter: invert(0.8)
+}


### PR DESCRIPTION
Coming across this repository was a great find for me! Thank you so much for putting in lots of efforts and creating this extensive java knowledge-base.

### Change Description: 

I just wanted to propose a minor styling enhancement for dark themed users. It seems that coffee icon logo is not properly visible in dark theme.

<img width="700" src="https://github.com/user-attachments/assets/c470ba9d-5f25-42b2-952e-c16f2e6ef95e">

### Results:

Tested in local

<img width="700" src="https://github.com/user-attachments/assets/42b08a02-37ab-49f0-a1ce-87417229f5f2">
